### PR TITLE
入力エラーについて一部メッセージボックスで表示される為コンソール出力に統一

### DIFF
--- a/DisplayDays.vb
+++ b/DisplayDays.vb
@@ -21,12 +21,12 @@ Public Class DisplayDays
 
         If Not r.IsMatch(inputValue) Then
 
-            MsgBox(instructions)
+            Console.WriteLine(instructions)
             Return
 
         ElseIf inputValue.Length <> 7 Then
 
-            MsgBox(instructions)
+            Console.WriteLine(instructions)
             Return
 
         End If


### PR DESCRIPTION
@nabemasamasa @Takatatsu9

入力エラーメッセージがメッセージボックスで表示される部分を、コンソール出力に統一されるよう修正いたしました。
お忙しいところ恐れ入りますがレビューお願いいたします。